### PR TITLE
Use transaction ID for transaction closing

### DIFF
--- a/includes/straal-checkout-notifications.php
+++ b/includes/straal-checkout-notifications.php
@@ -108,7 +108,7 @@ class WC_Gateway_Straal_Notifications {
 	 * @param object $notification_data JSON with notification details.
 	 */
 	protected function complete_order( $order, $notification_data ) {
-		$order->payment_complete( $notification_data->id );
+		$order->payment_complete( $notification_data->transaction->id );
 		WC()->cart->empty_cart();
 	}
 


### PR DESCRIPTION
Use transaction ID for transaction closing, fixes #4 